### PR TITLE
Add comment command support

### DIFF
--- a/Syntaxes/Logstash.Comments.tmPreferences
+++ b/Syntaxes/Logstash.Comments.tmPreferences
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>name</key>
+  <string>Comments</string>
+  <key>scope</key>
+  <string>text.logstash</string>
+  <key>settings</key>
+  <dict>
+    <key>shellVariables</key>
+    <array>
+      <dict>
+        <key>name</key>
+        <string>TM_COMMENT_START</string>
+        <key>value</key>
+        <string># </string>
+      </dict>
+    </array>
+  </dict>
+  <key>uuid</key>
+  <string>3d29dca5-934f-4171-b51b-9fcb0edf76ee</string>
+</dict>
+</plist>

--- a/Syntaxes/Logstash.tmPreferences
+++ b/Syntaxes/Logstash.tmPreferences
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
   <key>name</key>
-  <string>Comments</string>
+  <string>Logstash</string>
   <key>scope</key>
   <string>text.logstash</string>
   <key>settings</key>


### PR DESCRIPTION
Adding a tmPreferences file which defines `TM_COMMENT_START` for the Logstash syntax scope adds support for the comment/uncomment commands within Sublime Text.

http://docs.sublimetext.info/en/latest/reference/comments.html
