### PR TITLE
Let there be toggling them comments!

### DIFF
--- a/Syntaxes/Comments.tmPreferences
+++ b/Syntaxes/Comments.tmPreferences
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+   <key>name</key>
+   <string>Some description</string>
+   <key>scope</key>
+   <string>text.logstash</string>
+   <key>uuid</key>
+   <string>0A6EFEE7-61E4-4D9A-8568-92F105A62984</string>
+   <key>settings</key>
+   <dict>
+      <key>shellVariables</key>
+      <array>
+        <dict>
+            <key>name</key>
+            <string>TM_COMMENT_START</string>
+            <key>value</key>
+            <string># </string>
+        </dict>
+        <dict>
+            <key>name</key>
+            <string>TM_COMMENT_DISABLE_INDENT</string>
+            <key>value</key>
+            <string>yes</string>
+        </dict>
+      </array>
+   </dict>
+</dict>
+</plist>


### PR DESCRIPTION
Bring back toggle comment to work on Logstash Syntax Highlighter
Fixes #4 